### PR TITLE
Don't try to process API errors as responses

### DIFF
--- a/lib/pingdom.js
+++ b/lib/pingdom.js
@@ -354,6 +354,7 @@ function sendMessage(username, password, app_key, api, method, query, callback) 
 		if (response.statusCode > 399) {
 			logger.error('Got error response code %s, request failed.', response.statusCode);
 			callback.apply(this, [ null ]);
+			return;
 		}
 		
 		response.setEncoding('utf8');


### PR DESCRIPTION
`sendMessage` doesn't deal properly with error conditions. An HTTP status code > 399 will cause multiple invocations of the passed callback.
